### PR TITLE
[node-core-library]: update test case of LockFile#acquireAsync

### DIFF
--- a/libraries/node-core-library/src/test/LockFile.test.ts
+++ b/libraries/node-core-library/src/test/LockFile.test.ts
@@ -130,6 +130,8 @@ describe(LockFile.name, () => {
 
     const lock2Exists: boolean = await FileSystem.existsAsync(lock2.filePath);
     expect(lock2Exists).toEqual(true);
+    // The second lock should not be dirty since it is acquired after the first lock is released
+    expect(lock2.dirtyWhenAcquired).toEqual(false);
     expect(lock2.isReleased).toEqual(false);
 
     expect(lock2Acquired).toEqual(true);


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

Update test case of LockFile#acquireAsync function. Add check of `.dirtyWhenAcquired` property.

## Details

This is a related test case for issue [#5684](https://github.com/microsoft/rushstack/issues/5684)

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

- Use the old version of LockFile.ts to assert that the test doesn't pass
- Use the new version of LockFile.ts to assert that the test passes
